### PR TITLE
Photon Orb/Pulse Mine

### DIFF
--- a/client/weapons.json
+++ b/client/weapons.json
@@ -556,13 +556,13 @@
 			"ammo":-1,
 			"level":6,
 			"type":"Orb",
-			"bot":true,
-			"enabled":true
+			"bot":false,
+			"enabled":false
 		},
 		"43":{
 			"name":"Pulse Mine",
-			"range":50,
-			"damage":10,
+			"range":25,
+			"damage":8,
 			"speed":0,
 			"charge":30,
 			"price":8000,


### PR DESCRIPTION
Photon Orb and Energy Disk are the same exact thing; and Pulse Mine needs to be debuffed a little to avoid players spamming them to ruin others' gameplay