### PR TITLE
Lint: Enforce "no-mixed-operators", remove placebo rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,6 @@
         "prefer-const": 0,
 
         // More redundant manual linting.
-        "new-cap": 0,
         "eqeqeq": 0,
         "curly": 0,
         "camelcase": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,6 @@
         "no-sequences": 0,
 
         // Too lazy to fix.
-        "react/prop-types": 0,
         "react/no-string-refs": 0,
         "prefer-regex-literals": 0,
         "no-useless-escape": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
         "semi": [2, "always"],
         "quotes": [2, "backtick"],
         "prefer-template": 1,
+        "curly": 0,
 
         // ESLint globals have not been configured for these.
         "no-undef": 0,
@@ -43,9 +44,7 @@
 
         // More redundant manual linting.
         "eqeqeq": 0,
-        "curly": 0,
         "camelcase": 0,
-        "no-sequences": 0,
 
         // Too lazy to fix.
         "no-useless-escape": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,6 @@
 
         // ESLint globals have not been configured for these.
         "no-undef": 0,
-        "no-var": 0,
         "no-use-before-define": 0,
         "no-unused-vars": 0,
         "no-unused-expressions": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,6 @@
         "no-sequences": 0,
 
         // Too lazy to fix.
-        "react/no-string-refs": 0,
         "no-useless-escape": 0,
         "no-func-assign": 0,
         "no-global-assign": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,6 @@
 
         // Too lazy to fix.
         "react/no-string-refs": 0,
-        "prefer-regex-literals": 0,
         "no-useless-escape": 0,
         "no-func-assign": 0,
         "no-global-assign": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,22 +27,11 @@
         }
     },
     "rules": {
-        // Eval should not be allowed ever, regardless of use case.
         "no-eval": 2,
-
-        // } else {}
         "brace-style": 1,
-
-        // Indents should be four spaces.
-        "indent": ["warn", 4, {
-            "SwitchCase": 1
-        }],
-
-        // Semicolons and backticks should always be used.
+        "indent": ["warn", 4, { "SwitchCase": 1 }],
         "semi": [2, "always"],
         "quotes": [2, "backtick"],
-
-        // Use templating strings with backticks whenever possible.
         "prefer-template": 1,
 
         // ESLint globals have not been configured for these.
@@ -52,9 +41,6 @@
         "no-unused-vars": 0,
         "no-unused-expressions": 0,
         "prefer-const": 0,
-
-        // Unnecessary.
-        "no-mixed-operators": 0,
 
         // More redundant manual linting.
         "new-cap": 0,

--- a/client_src/graphics/render.js
+++ b/client_src/graphics/render.js
@@ -567,10 +567,11 @@ global.rBooms = function () {
             ctx.restore();
         }
 
-        if (!b.shockwave) {
-            continue;
-        }
-        rendX = b.x - px + w / 2 + scrx, rendY = b.y - py + h / 2 + scry;
+        if (!b.shockwave) continue;
+
+        rendX = b.x - px + w / 2 + scrx;
+        rendY = b.y - py + h / 2 + scry;
+
         const ss = Math.sqrt(b.time) * 96;
         ctx.globalAlpha = 0.9 - b.time / 500.0;
         ctx.drawImage(Img.shockwave, rendX - ss / 2, rendY - ss / 2, ss, ss);

--- a/client_src/index.jsx
+++ b/client_src/index.jsx
@@ -70,8 +70,6 @@ global.loginInProgress = false;
 
 window.document.title = `torn.space`;
 
-global.isChrome = true || !(!window.chrome) && !(!window.chrome.webstore);// broken
-
 global.canvas = document.querySelector(`#ctx`);
 
 canvas.width = window.innerWidth;

--- a/client_src/index.jsx
+++ b/client_src/index.jsx
@@ -264,7 +264,8 @@ setInterval(() => {
         canvas.width = w;
         canvas.height = h;
     }
-    baseMenuX = w / 2 - 128 * 3, baseMenuY = h / 4 - 128;
+    baseMenuX = w / 2 - 128 * 3;
+    baseMenuY = h / 4 - 128;
 }, 40);
 
 const loop = () => {
@@ -356,7 +357,10 @@ const loop = () => {
             ctx.drawImage((j % 2 == 0 ? Img.astUnderlayBlue : Img.astUnderlayGreen), -pw, -pw, pw * 2, pw * 2);
             angleNow = -Math.atan2(5 * Math.sin(5 * t), 4 * Math.cos(4 * t));
             ctx.rotate(angleNow + Math.PI / 2);
-            fireWidth = 32 * 1.2 * Math.sqrt(pw / 64), fireHeight = spd * 1.4 * pw / 64 + Math.random() * pw / 25;
+
+            fireWidth = 32 * 1.2 * Math.sqrt(pw / 64);
+            fireHeight = spd * 1.4 * pw / 64 + Math.random() * pw / 25;
+
             if (spd > 0) ctx.drawImage(Img.fire, 0, Math.floor(Math.random() * 8) * 64, 64, 64, -fireWidth / 2, 0, fireWidth, fireHeight);
             ctx.restore();
             ctx.save();

--- a/client_src/react/components/ChatInput.tsx
+++ b/client_src/react/components/ChatInput.tsx
@@ -24,6 +24,7 @@ declare const stopTyping: any;
 let ChatState: { init: any, activate: any, focusChat: any, unfocusChat: any };
 
 class ChatInput extends React.Component<{}, { value: string, activated: boolean }> {
+    chat: React.RefObject<HTMLInputElement>
     constructor (props: {}) {
         super(props);
 
@@ -31,6 +32,8 @@ class ChatInput extends React.Component<{}, { value: string, activated: boolean 
             value: ``,
             activated: false
         };
+
+        this.chat = React.createRef<HTMLInputElement>();
     }
 
     init = (data: { value: string, activated: boolean }) => {
@@ -42,11 +45,11 @@ class ChatInput extends React.Component<{}, { value: string, activated: boolean 
     }
 
     focusChat = () => {
-        (this.refs.chat as any).focus();
+        this.chat.current.focus();
     }
 
     unfocusChat = () => {
-        (this.refs.chat as any).blur();
+        this.chat.current.blur();
     }
 
     keypress = (event) => {
@@ -84,7 +87,7 @@ class ChatInput extends React.Component<{}, { value: string, activated: boolean 
         ? (
             <input
                 className="chat-input"
-                ref={`chat`}
+                ref={this.chat}
                 maxLength={128}
                 onKeyDown={this.keypress.bind(this)}
                 onChange={this.change.bind(this)}

--- a/server_src/battle/beam.js
+++ b/server_src/battle/beam.js
@@ -17,15 +17,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class Beam {
     constructor (ownr, i, weaponID, enemy, orign) {
-        this.type = `Beam`,
-        this.id = i, // unique identifier
-        this.dmg = wepns[weaponID].damage,
-        this.sx = ownr.sx,
-        this.sy = ownr.sy,
-        this.origin = orign,
-        this.owner = ownr,
-        this.enemy = enemy, // person we're hitting
-        this.wepnID = weaponID,
+        this.type = `Beam`;
+        this.id = i; // unique identifier
+        this.dmg = wepns[weaponID].damage;
+        this.sx = ownr.sx;
+        this.sy = ownr.sy;
+        this.origin = orign;
+        this.owner = ownr;
+        this.enemy = enemy; // person we're hitting
+        this.wepnID = weaponID;
         this.time = 0; // since spawn
     }
 

--- a/server_src/battle/bullet.js
+++ b/server_src/battle/bullet.js
@@ -19,23 +19,22 @@ const Vortex = require(`../universe/vortex.js`);
 
 class Bullet {
     constructor (ownr, i, wepnID, angl, info) {
-        this.type = `Bullet`,
-        this.id = i, // unique identifier
-        this.time = 0, // time since spawn
-        this.color = ownr.color, // whose team
-        this.dist = 0, // TRACKS distance. Doesn't control it.
-        this.dmg = wepns[wepnID].damage,
+        this.type = `Bullet`;
+        this.id = i; // unique identifier
+        this.time = 0; // time since spawn
+        this.color = ownr.color; // whose team
+        this.dist = 0; // TRACKS distance. Doesn't control it.
+        this.dmg = wepns[wepnID].damage;
 
-        this.x = ownr.x + (wepnID == 6 ? Math.sin(angl) * 16 * info : 0), // spawn where my owner was
-        this.y = ownr.y - (wepnID == 6 ? Math.cos(angl) * 16 * info : 0), // if minigun, move left or right based on which bullet I am
-        this.sx = ownr.sx,
-        this.sy = ownr.sy,
-        this.vx = Math.cos(angl) * wepns[wepnID].speed,
-        this.vy = Math.sin(angl) * wepns[wepnID].speed,
-
-        this.owner = ownr,
-        this.angle = angl, // has to be a parameter since not all bullets shoot straight
-        this.info = info, // used to differentiate left and right minigun bullets
+        this.x = ownr.x + (wepnID == 6 ? Math.sin(angl) * 16 * info : 0); // spawn where my owner was
+        this.y = ownr.y - (wepnID == 6 ? Math.cos(angl) * 16 * info : 0); // if minigun, move left or right based on which bullet I am
+        this.sx = ownr.sx;
+        this.sy = ownr.sy;
+        this.vx = Math.cos(angl) * wepns[wepnID].speed;
+        this.vy = Math.sin(angl) * wepns[wepnID].speed;
+        this.owner = ownr;
+        this.angle = angl; // has to be a parameter since not all bullets shoot straight
+        this.info = info; // used to differentiate left and right minigun bullets
         this.wepnID = wepnID;
     }
 

--- a/server_src/battle/mine.js
+++ b/server_src/battle/mine.js
@@ -39,7 +39,7 @@ class Mine {
 
     tick () {
         // All mines check for collision on placement; magnetic mine checks constantly as it heatseeks.
-        if ((this.time === 0 && [15, 16, 17, 32, 33].includes(this.wepnID)) || this.wepnID === 48) this.collideWithMines();
+        if ((this.time === 0 && [15, 16, 17, 32].includes(this.wepnID)) || this.wepnID === 48) this.collideWithMines();
 
         if (this.wepnID != 44) {
             this.collideWithGuns();

--- a/server_src/battle/mine.js
+++ b/server_src/battle/mine.js
@@ -38,7 +38,7 @@ class Mine {
     }
 
     tick () {
-        if (this.time == 0 && this.wepnID < 32 || this.wepnID > 47) this.collideWithMines(); // When the mine is created, make sure it isn't placed on top of any other mines.
+        if (this.time == 0 && [15, 16, 17, 32, 33, 43, 44, 48].includes(this.wepnID)) this.collideWithMines(); // When the mine is created, make sure it isn't placed on top of any other mines.
 
         if (this.wepnID != 44) {
             this.collideWithGuns();

--- a/server_src/battle/mine.js
+++ b/server_src/battle/mine.js
@@ -38,7 +38,8 @@ class Mine {
     }
 
     tick () {
-        if (this.time == 0 && [15, 16, 17, 32, 33, 43, 44, 48].includes(this.wepnID)) this.collideWithMines(); // When the mine is created, make sure it isn't placed on top of any other mines.
+        // All mines check for collision on placement; magnetic mine checks constantly as it heatseeks.
+        if ((this.time === 0 && [15, 16, 17, 32, 33].includes(this.wepnID)) || this.wepnID === 48) this.collideWithMines();
 
         if (this.wepnID != 44) {
             this.collideWithGuns();

--- a/server_src/battle/mine.js
+++ b/server_src/battle/mine.js
@@ -19,21 +19,21 @@ const Beam = require(`./beam.js`);
 
 class Mine {
     constructor (ownr, i, weaponID) {
-        this.type = `Mine`,
-        this.id = i, // unique identifier
-        this.time = 0, // time since spawned
-        this.color = ownr.color, // what team owns me
-        this.dmg = wepns[weaponID].damage,
-        this.range = wepns[weaponID].range,
+        this.type = `Mine`;
+        this.id = i; // unique identifier
+        this.time = 0; // time since spawned
+        this.color = ownr.color; // what team owns me
+        this.dmg = wepns[weaponID].damage;
+        this.range = wepns[weaponID].range;
 
-        this.x = ownr.x,
-        this.y = ownr.y,
-        this.vx = Math.cos(ownr.angle) * wepns[weaponID].speed, // grenades are the only mines that move on its own
-        this.vy = Math.sin(ownr.angle) * wepns[weaponID].speed,
-        this.sx = ownr.sx,
-        this.sy = ownr.sy,
+        this.x = ownr.x;
+        this.y = ownr.y;
+        this.vx = Math.cos(ownr.angle) * wepns[weaponID].speed; // grenades are the only mines that move on its own
+        this.vy = Math.sin(ownr.angle) * wepns[weaponID].speed;
+        this.sx = ownr.sx;
+        this.sy = ownr.sy;
 
-        this.owner = ownr,
+        this.owner = ownr;
         this.wepnID = weaponID;
     }
 

--- a/server_src/battle/missile.js
+++ b/server_src/battle/missile.js
@@ -17,27 +17,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class Missile {
     constructor (ownr, i, wepnID, angl) {
-        this.type = `Missile`,
-        this.id = i, // unique identifier
-        this.color = ownr.color, // whose side i'm on
-        this.dmg = wepns[wepnID].damage,
+        this.type = `Missile`;
+        this.id = i; // unique identifier
+        this.color = ownr.color; // whose side i'm on
+        this.dmg = wepns[wepnID].damage;
 
-        this.x = ownr.x,
-        this.y = ownr.y,
-        this.sx = ownr.sx,
-        this.sy = ownr.sy,
-        this.vx = Math.cos(angl) * wepns[wepnID].speed,
-        this.vy = Math.sin(angl) * wepns[wepnID].speed,
-        this.emvx = 0,
-        this.emvy = 0,
-        this.angle = angl,
+        this.x = ownr.x;
+        this.y = ownr.y;
+        this.sx = ownr.sx;
+        this.sy = ownr.sy;
+        this.vx = Math.cos(angl) * wepns[wepnID].speed;
+        this.vy = Math.sin(angl) * wepns[wepnID].speed;
+        this.emvx = 0;
+        this.emvy = 0;
+        this.angle = angl;
 
-        this.owner = ownr,
-        this.locked = 0, // player I'm locked onto
-        this.timer = 0, // since spawn
-        this.lockedTimer = 0, // since locking on to my current target (or is it since first locking onto anyone?)
-        this.distTravelled = 0, // distance I've travelled
-        this.wepnID = wepnID,
+        this.owner = ownr;
+        this.locked = 0; // player I'm locked onto
+        this.timer = 0; // since spawn
+        this.lockedTimer = 0; // since locking on to my current target (or is it since first locking onto anyone?)
+        this.distTravelled = 0; // distance I've travelled
+        this.wepnID = wepnID;
         this.goalAngle = 0; // the angle I'm turning to match
     }
 

--- a/server_src/battle/orb.js
+++ b/server_src/battle/orb.js
@@ -16,22 +16,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 class Orb {
     constructor (ownr, i, wepnID) { // currently the only orbs are energy disk and photon orb
-        this.type = `Orb`,
-        this.id = i, // unique identifier
-        this.color = ownr.color, // owned by which team
-        this.dmg = wepns[wepnID].damage,
+        this.type = `Orb`;
+        this.id = i; // unique identifier
+        this.color = ownr.color; // owned by which team
+        this.dmg = wepns[wepnID].damage;
 
-        this.owner = ownr,
-        this.x = ownr.x,
-        this.y = ownr.y, // spawn where its owner is
-        this.sx = ownr.sx,
-        this.sy = ownr.sy,
-        this.vx = wepns[wepnID].speed * Math.cos(ownr.angle) * 2,
-        this.vy = wepns[wepnID].speed * Math.sin(ownr.angle) * 2,
+        this.owner = ownr;
+        this.x = ownr.x;
+        this.y = ownr.y; // spawn where its owner is
+        this.sx = ownr.sx;
+        this.sy = ownr.sy;
+        this.vx = wepns[wepnID].speed * Math.cos(ownr.angle) * 2;
+        this.vy = wepns[wepnID].speed * Math.sin(ownr.angle) * 2;
 
-        this.locked = 0, // the id of the player I'm locked on to
-        this.timer = 0, // how long this orb has existed
-        this.lockedTimer = 0, // timer of how long it's been locked onto a player
+        this.locked = 0; // the id of the player I'm locked on to
+        this.timer = 0; // how long this orb has existed
+        this.lockedTimer = 0; // timer of how long it's been locked onto a player
         this.wepnID = wepnID;
     }
 

--- a/server_src/command.js
+++ b/server_src/command.js
@@ -219,7 +219,7 @@ cmds.unmute = new Command(`/unmute <player> - You will begin hearing the player'
     commandExecuter.socket.emit(`chat`, { msg: `Unmuted ${name}.` });
 });
 
-const valid_email_regex = new RegExp(`^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$`);
+const valid_email_regex = `^(([^<>()\\[\\]\\\\.,;:\\s@"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@"]+)*)|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$`;
 
 cmds.email = new Command(`/email <you@domain.tld> - Sets your email for password resets`, REGISTERED, (commandExecuter, msg) => {
     const email = msg.substring(7);

--- a/server_src/player.js
+++ b/server_src/player.js
@@ -984,9 +984,9 @@ class Player {
             this.health -= 10000;
         }
 
-        if (this.empTimer <= 0 && origin.type === `Asteroid` || (origin.type === `Beam` && origin.wepnID == 8)) { // navigational shield fails when EMPd
-            if (this.navigationalShield > 0) d /= (origin.type === `Asteroid` ? 2048 : 5);
-        }
+        // If player is not EMP'd, has navigational shield, and they are hit either by an asteroid or laser beam. then activate navigational shield perks.
+        if (this.empTimer <= 0 && this.navigationalShield > 0 &&
+            ((origin.type === `Beam` && origin.wepnID === 8) || origin.type === `Asteroid`)) d /= (origin.type === `Asteroid` ? 2048 : 5);
 
         d /= (this.trail % 16 == 1 ? 1.05 : 1); // blood trail: less damage
         d *= ((this.shield && d > 0) ? 0.25 : 1); // Shield- 1/4th damage. Won't block healing items

--- a/server_src/player.js
+++ b/server_src/player.js
@@ -28,74 +28,74 @@ let nextPlayerId = 0;
 
 class Player {
     constructor () {
-        this.name = ``,
-        this.type = `Player`,
+        this.name = ``;
+        this.type = `Player`;
 
-        this.tag = ``,
-        this.id = nextPlayerId++, // unique identifier
-        this.trail = 0,
-        this.color = `yellow`,
-        this.elo = 1200,
-        this.ship = 0,
-        this.experience = 0,
-        this.rank = 0,
+        this.tag = ``;
+        this.id = nextPlayerId++; // unique identifier
+        this.trail = 0;
+        this.color = `yellow`;
+        this.elo = 1200;
+        this.ship = 0;
+        this.experience = 0;
+        this.rank = 0;
 
-        this.guest = false,
-        this.dead = false,
-        this.docked = false,
+        this.guest = false;
+        this.dead = false;
+        this.docked = false;
 
         // misc timers
-        this.noDrift = 50, // A timer used for decelerating angular momentum
-        this.jukeTimer = 0,
-        this.hyperdriveTimer = -1,
-        this.borderJumpTimer = 0, // for deciding whether to hurt the player
-        this.planetTimer = 0,
-        this.leaveBaseShield = 0,
+        this.noDrift = 50; // A timer used for decelerating angular momentum
+        this.jukeTimer = 0;
+        this.hyperdriveTimer = -1;
+        this.borderJumpTimer = 0; // for deciding whether to hurt the player
+        this.planetTimer = 0;
+        this.leaveBaseShield = 0;
         this.superchargerTimer = -1;
-        this.empTimer = -1,
-        this.disguise = -1,
-        this.timer = 0,
-        this.gyroTimer = 0,
-        this.charge = 0,
+        this.empTimer = -1;
+        this.disguise = -1;
+        this.timer = 0;
+        this.gyroTimer = 0;
+        this.charge = 0;
 
-        this.weapons = {}, // my equipped weapons and ammo counts
-        this.ammos = {},
-        this.bulletQueue = 0, // For submachinegun (5 bullet bursts)
+        this.weapons = {}; // my equipped weapons and ammo counts
+        this.ammos = {};
+        this.bulletQueue = 0; // For submachinegun (5 bullet bursts)
 
-        this.sx = 0, // sector
-        this.sy = 0,
-        this.x = sectorWidth / 2,
-        this.y = sectorWidth / 2,
-        this.vx = 0,
-        this.vy = 0,
-        this.cva = 0,
-        this.angle = 0,
-        this.speed = 0,
-        this.driftAngle = 0,
+        this.sx = 0; // sector
+        this.sy = 0;
+        this.x = sectorWidth / 2;
+        this.y = sectorWidth / 2;
+        this.vx = 0;
+        this.vy = 0;
+        this.cva = 0;
+        this.angle = 0;
+        this.speed = 0;
+        this.driftAngle = 0;
 
-        this.money = 8000,
-        this.kills = 0,
-        this.killStreakTimer = -1,
-        this.killStreak = 0,
-        this.baseKills = 0,
+        this.money = 8000;
+        this.kills = 0;
+        this.killStreakTimer = -1;
+        this.killStreak = 0;
+        this.baseKills = 0;
 
-        this.shield = false,
+        this.shield = false;
         this.navigationalShield = 0;
-        this.generators = 0,
-        this.isLocked = false,
-        this.lives = 20,
-        this.quest = 0,
-        this.health = 1,
+        this.generators = 0;
+        this.isLocked = false;
+        this.lives = 20;
+        this.quest = 0;
+        this.health = 1;
 
-        this.iron = 0,
-        this.silver = 0,
-        this.platinum = 0,
-        this.copper = 0,
+        this.iron = 0;
+        this.silver = 0;
+        this.platinum = 0;
+        this.copper = 0;
 
         // bot stuff
-        this.net = 0, // where the neural network is stored
-        this.isBot = false,
-        this.isNNBot = false,
+        this.net = 0; // where the neural network is stored
+        this.isBot = false;
+        this.isNNBot = false;
 
         /* please don't touch these
                nearestEnemyDist = 0,//for nnBots
@@ -112,38 +112,38 @@ class Player {
                nearestBulletAngleV = 0,
                */
 
-        this.thrust = 1, // These are techs multiplied by ship stats, used for actual physics
-        this.va = 1,
-        this.capacity = 1,
-        this.maxHealth = 2,
+        this.thrust = 1; // These are techs multiplied by ship stats, used for actual physics
+        this.va = 1;
+        this.capacity = 1;
+        this.maxHealth = 2;
 
-        this.thrust2 = 1, // these just track the player tech levels
-        this.radar2 = 1,
-        this.agility2 = 1,
-        this.capacity2 = 1,
-        this.maxHealth2 = 1,
-        this.energy2 = 1,
+        this.thrust2 = 1; // these just track the player tech levels
+        this.radar2 = 1;
+        this.agility2 = 1;
+        this.capacity2 = 1;
+        this.maxHealth2 = 1;
+        this.energy2 = 1;
 
-        this.w = false, // what keys are pressed currently
-        this.s = false,
-        this.a = false,
-        this.d = false,
-        this.e = false,
-        this.c = false,
-        this.space = false,
+        this.w = false; // what keys are pressed currently
+        this.s = false;
+        this.a = false;
+        this.d = false;
+        this.e = false;
+        this.c = false;
+        this.space = false;
 
-        this.killAchievements = {}, // 10 of em. Lengths are written in torn_globals.js
-        this.moneyAchievements = {}, // 5
-        this.driftAchievements = {}, // 5
-        this.randomAchievements = {}, // 5
+        this.killAchievements = {}; // 10 of em. Lengths are written in torn_globals.js
+        this.moneyAchievements = {}; // 5
+        this.driftAchievements = {}; // 5
+        this.randomAchievements = {}; // 5
 
         // various achievement stuff
-        this.driftTimer = 0, // How many ticks this account has been drifting.
-        this.cornersTouched = 0, // bitmask
-        this.oresMined = 0, // bitmask
-        this.questsDone = 0, // bitmask
-        this.planetsClaimed = `0000000` + `0000000` + `0000000` + `0000000` + `0000000` + `0000000` + `0000000`,
-        this.points = 0,
+        this.driftTimer = 0; // How many ticks this account has been drifting.
+        this.cornersTouched = 0; // bitmask
+        this.oresMined = 0; // bitmask
+        this.questsDone = 0; // bitmask
+        this.planetsClaimed = `0000000` + `0000000` + `0000000` + `0000000` + `0000000` + `0000000` + `0000000`;
+        this.points = 0;
 
         this.equipped = 0;
     }

--- a/server_src/universe/asteroid.js
+++ b/server_src/universe/asteroid.js
@@ -30,19 +30,19 @@ for (let i = 0; i < mapSz; i++) {
 
 class Asteroid {
     constructor (i, h, sx, sy, x, y, vx, vy, metal) {
-        this.type = `Asteroid`,
-        this.owner = 0,
-        this.id = i, // unique identifier
-        this.x = x,
-        this.y = y,
-        this.angle = 0,
-        this.health = h,
-        this.maxHealth = h,
-        this.sx = sx,
-        this.sy = sy,
-        this.vx = vx,
-        this.vy = vy,
-        this.metal = metal,
+        this.type = `Asteroid`;
+        this.owner = 0;
+        this.id = i; // unique identifier
+        this.x = x;
+        this.y = y;
+        this.angle = 0;
+        this.health = h;
+        this.maxHealth = h;
+        this.sx = sx;
+        this.sy = sy;
+        this.vx = vx;
+        this.vy = vy;
+        this.metal = metal;
         this.va = (Math.random() - 0.5) / 10;
         if (this.vx == 0 && this.vy == 0) {
             this.vx = 3 * (Math.random() - 0.5);

--- a/server_src/universe/base.js
+++ b/server_src/universe/base.js
@@ -30,33 +30,33 @@ global.TURRET = 2;
 global.SENTRY = 3;
 
 class Base {
-    constructor (i, type, sx, syy, col, x, y) {
+    constructor (i, type, sx, sy, col, x, y) {
         console.log(`Base constructed with type ${type}`);
-        this.type = `Base`,
-        this.kills = 0,
-        this.experience = 0,
-        this.money = 0,
-        this.id = i, // unique identifier
-        this.trueColor = col, // The team this base originally is
-        this.color = col, // The team this base is now
-        this.assimilatedCol = col, // The team that is attempting to overtake the base
-        this.owner = 0,
-        this.name = ``,
-        this.isMini = (type == SENTRY),
-        this.baseType = type, // Constants above
-        this.angle = 0, // angle of the turret
+        this.type = `Base`;
+        this.kills = 0;
+        this.experience = 0;
+        this.money = 0;
+        this.id = i; // unique identifier
+        this.trueColor = col; // The team this base originally is
+        this.color = col; // The team this base is now
+        this.assimilatedCol = col; // The team that is attempting to overtake the base
+        this.owner = 0;
+        this.name = ``;
+        this.isMini = (type == SENTRY);
+        this.baseType = type; // Constants above
+        this.angle = 0; // angle of the turret
 
-        this.x = x,
-        this.y = y,
-        this.sx = sx,
-        this.sy = syy,
-        this.deathTimer = 0,
+        this.x = x;
+        this.y = y;
+        this.sx = sx;
+        this.sy = sy;
+        this.deathTimer = 0;
 
-        this.shots = 0,
-        this.reload = 0, // timer for shooting
-        this.health = (type == SENTRY ? 0.15 : 1) * baseHealth,
-        this.maxHealth = (type == SENTRY ? 0.15 : 1) * baseHealth,
-        this.empTimer = -1,
+        this.shots = 0;
+        this.reload = 0; // timer for shooting
+        this.health = (type == SENTRY ? 0.15 : 1) * baseHealth;
+        this.maxHealth = (type == SENTRY ? 0.15 : 1) * baseHealth;
+        this.empTimer = -1;
         this.speed = 0; // vs unused but there for bullets,
         this.assimilatedTimer = 0;
     }

--- a/server_src/universe/package.js
+++ b/server_src/universe/package.js
@@ -17,12 +17,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class Package {
     constructor (ownr, i, type) {
-        this.id = i, // unique identifier
-        this.type = type, // ammo? coin? lives? actual courier package?
-        this.x = ownr.x,
-        this.y = ownr.y,
-        this.sx = ownr.sx,
-        this.sy = ownr.sy,
+        this.id = i; // unique identifier
+        this.type = typ; // ammo? coin? lives? actual courier package?
+        this.x = ownr.x;
+        this.y = ownr.y;
+        this.sx = ownr.sx;
+        this.sy = ownr.sy;
         this.time = 0; // since spawn
     }
 

--- a/server_src/universe/planet.js
+++ b/server_src/universe/planet.js
@@ -17,15 +17,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class Planet {
     constructor (i, name) {
-        this.type = `Planet`,
-        this.name = name,
-        this.color = `yellow`,
-        this.owner = 0, // string name of the player who owns it.
-        this.id = i, // unique identifier
-        this.x = sectorWidth / 2, // this is updated by the createPlanet function to a random location
-        this.y = sectorWidth / 2,
-        this.cooldown = 0, // to prevent chat "planet claimed" spam
-        this.sx = 0,
+        this.type = `Planet`;
+        this.name = name;
+        this.color = `yellow`;
+        this.owner = 0; // string name of the player who owns it.
+        this.id = i; // unique identifier
+        this.x = sectorWidth / 2; // this is updated by the createPlanet function to a random location
+        this.y = sectorWidth / 2;
+        this.cooldown = 0; // to prevent chat "planet claimed" spam
+        this.sx = 0;
         this.sy = 0;
     }
 

--- a/server_src/universe/vortex.js
+++ b/server_src/universe/vortex.js
@@ -16,24 +16,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 class Vortex {
-    constructor (i, x, y, sxx, syy, size, ownr, isWorm) {
-        this.isWorm = isWorm, // am i a wormhole or black hole
-        this.sxo = Math.floor(Math.random() * mapSz), // output node location for wormhole
-        this.syo = Math.floor(Math.random() * mapSz),
-        this.xo = Math.random() * sectorWidth,
-        this.yo = Math.random() * sectorWidth,
+    constructor (i, x, y, sx, sy, size, ownr, isWorm) {
+        this.isWorm = isWorm; // am i a wormhole or black hole
+        this.sxo = Math.floor(Math.random() * mapSz); // output node location for wormhole
+        this.syo = Math.floor(Math.random() * mapSz);
+        this.xo = Math.random() * sectorWidth;
+        this.yo = Math.random() * sectorWidth;
 
-        this.type = `Vortex`,
-        this.wepnID = 28,
-        this.owner = ownr,
-        this.id = i, // unique identifier
+        this.type = `Vortex`;
+        this.wepnID = 28;
+        this.owner = ownr;
+        this.id = i; // unique identifier
 
-        this.vx = 0,
-        this.vy = 0,
-        this.x = x, // input node or black hole location
-        this.y = y,
-        this.sx = sxx,
-        this.sy = syy,
+        this.vx = 0;
+        this.vy = 0;
+        this.x = x; // input node or black hole location
+        this.y = y;
+        this.sx = sx;
+        this.sy = sy;
 
         this.size = size;
     }


### PR DESCRIPTION
The main focus of this PR is that it enforces no-mixed-operators, fixing certain conditionals that are unclear and not apparent to the eye, as well as remove certain 'placebo' rules that throw no errors but are disabled.

This also fixes navigational shield activation, which had used mixed operators, along with reformatting from fixing other rules (non-logic-changing).

Linting configuration has also been started to be condensed, as JSON comments are not supported across all systems / editors.